### PR TITLE
Feat/disable temp.temp

### DIFF
--- a/MedialCurve.cpp
+++ b/MedialCurve.cpp
@@ -233,7 +233,7 @@ MedialCurve::MedialCurve(string filename, int off, bool ying)
 	f.close();
 
 	// Checkpoint message: reposition system to center
-	cout << "Centering point in 3-D space...";
+	cout << "Centering point in 3-D space..." << std::endl;
 	name = filename;
 	//find the middle place of the root
 	int midx = minx + (int)ceil((float)((maxx - minx) / 2));

--- a/MedialCurve.cpp
+++ b/MedialCurve.cpp
@@ -1495,8 +1495,7 @@ double MedialCurve::computeConvexVolume()
 	//coordT *points = &(boundvoxs[0]);           // array of coordinates for each point //
 	boolT ismalloc=False;           // True if qhull should free points in qh_freeqhull() or reallocation //
 	char flags[]= "qhull Tv FA"; // option flags for qhull, see qh_opt.htm //
-	FILE *outfile= fopen("temp.temp","w");//stdout;    // output from qh_produce_output()
-	                             //use NULL to skip qh_produce_output() //
+	FILE* outfile = NULL;  // output from qh_produce_output(), use NULL to skip qh_produce_output() //
 	FILE *errfile= stderr;    // error messages from qhull code //
 	int exitcode;             // 0 if no error from qhull //
 	//facetT *facet;	          // set by FORALLfacets //
@@ -1541,7 +1540,7 @@ void MedialCurve::computeSweepingFeatures(double &medR, double &maxR, double &ma
 	double *pts;
 	boolT ismalloc=False;           // True if qhull should free points in qh_freeqhull() or reallocation //
 	char flags[]= "qhull FA"; // option flags for qhull, see qh_opt.htm //
-	FILE *outfile= fopen("temp.temp","w");//stdout;    // output from qh_produce_output() use NULL to skip qh_produce_output() //
+	FILE* outfile = NULL;  // output from qh_produce_output(), use NULL to skip qh_produce_output() //
 	FILE *errfile= stderr;    // error messages from qhull code //
 	int exitcode;             // 0 if no error from qhull //
 	//facetT *facet;	          // set by FORALLfacets //

--- a/menu.cpp
+++ b/menu.cpp
@@ -110,13 +110,5 @@ void skel_and_features_pipeline(string fileinput, string fileoutput, float scale
 	for (i = 0; i < sk_features.size(); ++i)
 		fprintf(ff, "%.4f\t", sk_features.at(i).second);
 	fclose(ff);
-
-	/*if( remove( "temp.temp" ) != 0 )
-		perror( "Error deleting file" );
-	else
-		puts( "File successfully deleted" );*/
-
-	//remove("C:\Olga\development\root3D_clean\Release\temp.temp");
-
 	cout << "\nDONE. Exiting." << endl;
 }

--- a/util.cpp
+++ b/util.cpp
@@ -45,6 +45,10 @@ void tokenize(const string& str,
 }
 /**
 * write the object MedialCurve into IV and VRML(WRL) file
+* @param filename input path
+* @param m medial curve representation of object
+* @param type output file format, '1' saves object as .iv; '2' saves object
+ *			  as .wrl
 */
 void writeVisibleIvWrlEff(string filename, MedialCurve &m, int type)
 {
@@ -375,7 +379,7 @@ void writeVisibleIvWrlEff(string filename, MedialCurve &m, int type)
 	}
 	// Checkpoint message: Create WRL output file
 	int linesToProcess = (int)coordall.size() + (int)inds.size();
-	cout << "Writing WRL '" << filename << "' (" << linesToProcess << ")" << endl;
+	cout << "Writing WRL '" << filename << "' (line count: " << linesToProcess << ")" << endl;
 
 	// add comma after every point, except for the last one
 	// to be able to view IV file with IV Viewer (installed on BioRoss Linux server) otherwise it does not work -
@@ -386,7 +390,8 @@ void writeVisibleIvWrlEff(string filename, MedialCurve &m, int type)
 	for (int i = 0; i < last; i++)
 	{
 		ptCounter++;
-		if ((ptCounter - 1) % int(floor(last/200)) == 0 || ptCounter == last)
+		// if ((ptCounter - 1) % int(floor(last/200)) == 0 || ptCounter == last)
+		if (ptCounter == last)
 		{
 			cout << "\rWrite point " << ptCounter << " of " << last << " from " << filename << " to mesh" << flush;
 		}
@@ -422,7 +427,8 @@ void writeVisibleIvWrlEff(string filename, MedialCurve &m, int type)
 	for (int i = 0; i < last2; i++)
 	{
 			ptCounter++;
-		if ((ptCounter - 1) % int(floor(last2/200)) == 0 || ptCounter == last2)
+		// if ((ptCounter - 1) % int(floor(last2/200)) == 0 || ptCounter == last2)
+		if (ptCounter == last2)
 		{
 			cout << "\rWrite face " << ptCounter << " of " << last2 << " from " << filename << " to mesh" << flush;
 		}


### PR DESCRIPTION
Disables the generation of `temp.temp` files when calculating the convex hull using a third-party library. Minor tweaks to log messages as well.